### PR TITLE
Setup CNAME 2024.kaigionrails.org

### DIFF
--- a/dns/kaigionrails_org.tf
+++ b/dns/kaigionrails_org.tf
@@ -36,9 +36,12 @@ resource "cloudflare_record" "cname_2023" {
   ttl     = 300
 }
 
-import {
-  to = cloudflare_record.cname_2023
-  id = "13373bcb6ae8d714dc8b48e6204df945/ac1e9c18601c60e5d6c647e2d22d3efe"
+resource "cloudflare_record" "cname_2024" {
+  zone_id = cloudflare_zone.kaigionrails_org.id
+  name    = "2024"
+  type    = "CNAME"
+  value   = "kaigionrails.github.io"
+  ttl     = 300
 }
 
 resource "cloudflare_record" "google_verify" {


### PR DESCRIPTION
## what
publish https://github.com/kaigionrails/kaigi-on-rails-2024

### terraform plan
```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # cloudflare_record.cname_2024 will be created
  + resource "cloudflare_record" "cname_2024" {
      + allow_overwrite = false
      + created_on      = (known after apply)
      + hostname        = (known after apply)
      + id              = (known after apply)
      + metadata        = (known after apply)
      + modified_on     = (known after apply)
      + name            = "2024"
      + proxiable       = (known after apply)
      + ttl             = 300
      + type            = "CNAME"
      + value           = "kaigionrails.github.io"
      + zone_id         = "13373bcb6ae8d714dc8b48e6204df945"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```